### PR TITLE
docs: outline agents and switch personal assistant to local llms

### DIFF
--- a/Personal Assistant.json
+++ b/Personal Assistant.json
@@ -279,12 +279,14 @@
         "model": {
           "__rl": true,
           "mode": "list",
-          "value": "claude-sonnet-4-20250514",
+          "value": "qwen2-7b-instruct",
           "cachedResultName": "Claude 4 Sonnet"
         },
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        }
       },
-      "type": "@n8n/n8n-nodes-langchain.lmChatAnthropic",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
       "position": [
         -832,
@@ -293,9 +295,9 @@
       "id": "f60bc37c-4c92-4975-b578-13f04f174fce",
       "name": "Anthropic Chat Model",
       "credentials": {
-        "anthropicApi": {
-          "id": "KztKfqsNjNkkJM89",
-          "name": "Anthropic account"
+        "openAiApi": {
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },
@@ -627,11 +629,13 @@
       "parameters": {
         "model": {
           "__rl": true,
-          "value": "gpt-4.1-mini",
+          "value": "phi-3-mini",
           "mode": "list",
           "cachedResultName": "gpt-4.1-mini"
         },
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        }
       },
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.2,
@@ -643,8 +647,8 @@
       "name": "GPT-5-Nano",
       "credentials": {
         "openAiApi": {
-          "id": "ybRg3lag38rmtn5D",
-          "name": "Shab OpenAi account"
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },
@@ -2313,7 +2317,10 @@
       "parameters": {
         "resource": "audio",
         "operation": "transcribe",
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        },
+        "model": "faster-whisper"
       },
       "type": "@n8n/n8n-nodes-langchain.openAi",
       "typeVersion": 1.8,
@@ -2325,8 +2332,8 @@
       "name": "OpenAI",
       "credentials": {
         "openAiApi": {
-          "id": "ybRg3lag38rmtn5D",
-          "name": "Shab OpenAi account"
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },
@@ -2501,11 +2508,13 @@
       "parameters": {
         "model": {
           "__rl": true,
-          "value": "gpt-4.1",
+          "value": "mixtral-8x7b",
           "mode": "list",
           "cachedResultName": "gpt-4.1"
         },
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        }
       },
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.2,
@@ -2517,8 +2526,8 @@
       "name": "GPT-4.1",
       "credentials": {
         "openAiApi": {
-          "id": "ybRg3lag38rmtn5D",
-          "name": "Shab OpenAi account"
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },

--- a/docs/AI_Project_Management.md
+++ b/docs/AI_Project_Management.md
@@ -1,18 +1,28 @@
-# Agent zarządzania projektami
+# Agent zarządzania projektami (jak kierownik w Asanie)
 
-## Przegląd
-- Zbudowany w n8n i LangChain do obsługi projektów w Asanie.
-- Główny model LLM to Anthropic Claude.
-- Kontekst rozmowy przechowywany jest w **Simple Memory**, a narzędzie **Think** pomaga w rozumowaniu.
-- Zawiera dedykowane węzły Asany do tworzenia projektów, zadań, podzadań oraz wyszukiwania użytkowników.
+## Co robi?
+Wyobraź sobie kierownika, któremu mówisz „zrób projekt” i on od razu tworzy go
+w Asanie. Ten agent słucha twoich poleceń na czacie i wykonuje je w Asanie:
+dodaje projekty, zadania, a nawet podzadania.
 
-## Przepływ
-1. Wyzwalacz czatu przekazuje wiadomość do agenta **Project Manager**.
-2. Agent decyduje, którego narzędzia Asany użyć: utworzyć projekt, zadanie, podzadanie czy wyszukać użytkownika.
-3. Historia rozmowy zapisywana jest w **Simple Memory**, aby agent miał kontekst.
+## Jak działa
+1. **Piszesz polecenie** – np. „Stwórz projekt Strona WWW”.
+2. **Agent Project Manager** rozumie, o co prosisz i wybiera odpowiednią akcję w
+   Asanie.
+3. **Simple Memory** zapamiętuje rozmowę, więc agent pamięta, nad czym
+   pracujecie.
+4. **Think** pomaga mu lepiej zrozumieć złożone instrukcje.
 
-## Przełączenie na modele lokalne
-1. Uruchom lokalny serwer LLM (np. LocalAI, Ollama) udostępniający endpoint zgodny z OpenAI `/v1`.
-2. Zamień węzeł Anthropic Claude na węzeł typu OpenAI, wskazujący na lokalny serwer.
-3. Ustaw parametr `model` na nazwę lokalnego modelu (np. `llama3-8b-instruct`) oraz `baseUrl` na adres serwera.
-4. W n8n zaktualizuj poświadczenia tak, aby nie używać kluczy API i kierować zapytania na lokalny serwer.
+## Jak uruchomić
+1. W n8n kliknij **Import** i wybierz plik `AI Project Management.json`.
+2. W zakładce **Credentials** dodaj klucz API do Asany.
+3. Węzeł z modelem LLM ustaw na lokalny, zgodnie z poradnikiem
+   [Local_LLM_Setup.md](Local_LLM_Setup.md) (np. `llama3-8b`).
+4. Kliknij **Execute Workflow** i wpisuj polecenia w okienku czatu n8n.
+
+## Przykład użycia
+```
+Ty: "Dodaj zadanie 'Naprawić bugi' do projektu 'Strona WWW'"
+Agent: "Gotowe, zadanie dodane!"
+```
+

--- a/docs/AI_Project_Management.md
+++ b/docs/AI_Project_Management.md
@@ -1,18 +1,18 @@
-# AI Project Management Agent
+# Agent zarządzania projektami
 
-## Overview
-- Built with n8n and LangChain to manage Asana projects.
-- Uses an Anthropic Claude model as the main LLM.
-- Maintains conversation context via **Simple Memory** and leverages a **Think** tool for reasoning.
-- Includes dedicated Asana nodes for creating projects, tasks, subtasks and for user lookup.
+## Przegląd
+- Zbudowany w n8n i LangChain do obsługi projektów w Asanie.
+- Główny model LLM to Anthropic Claude.
+- Kontekst rozmowy przechowywany jest w **Simple Memory**, a narzędzie **Think** pomaga w rozumowaniu.
+- Zawiera dedykowane węzły Asany do tworzenia projektów, zadań, podzadań oraz wyszukiwania użytkowników.
 
-## Flow
-1. Chat trigger sends user input to the **Project Manager** agent.
-2. The agent decides which Asana tool to use: create project, task, subtask or find user.
-3. Conversation history is stored in **Simple Memory** to give the agent context.
+## Przepływ
+1. Wyzwalacz czatu przekazuje wiadomość do agenta **Project Manager**.
+2. Agent decyduje, którego narzędzia Asany użyć: utworzyć projekt, zadanie, podzadanie czy wyszukać użytkownika.
+3. Historia rozmowy zapisywana jest w **Simple Memory**, aby agent miał kontekst.
 
-## Switching to Local Models
-1. Run a local LLM server (e.g. LocalAI, Ollama) exposing an OpenAI-compatible `/v1` endpoint.
-2. Replace the Anthropic Claude node with an OpenAI-compatible chat node pointing at your local server.
-3. Update the node's `model` value to your chosen local model (e.g. `llama3-8b-instruct`) and set the `baseUrl` option to the local endpoint.
-4. Update credentials in n8n to remove remote API keys and reference the local server instead.
+## Przełączenie na modele lokalne
+1. Uruchom lokalny serwer LLM (np. LocalAI, Ollama) udostępniający endpoint zgodny z OpenAI `/v1`.
+2. Zamień węzeł Anthropic Claude na węzeł typu OpenAI, wskazujący na lokalny serwer.
+3. Ustaw parametr `model` na nazwę lokalnego modelu (np. `llama3-8b-instruct`) oraz `baseUrl` na adres serwera.
+4. W n8n zaktualizuj poświadczenia tak, aby nie używać kluczy API i kierować zapytania na lokalny serwer.

--- a/docs/AI_Project_Management.md
+++ b/docs/AI_Project_Management.md
@@ -1,0 +1,18 @@
+# AI Project Management Agent
+
+## Overview
+- Built with n8n and LangChain to manage Asana projects.
+- Uses an Anthropic Claude model as the main LLM.
+- Maintains conversation context via **Simple Memory** and leverages a **Think** tool for reasoning.
+- Includes dedicated Asana nodes for creating projects, tasks, subtasks and for user lookup.
+
+## Flow
+1. Chat trigger sends user input to the **Project Manager** agent.
+2. The agent decides which Asana tool to use: create project, task, subtask or find user.
+3. Conversation history is stored in **Simple Memory** to give the agent context.
+
+## Switching to Local Models
+1. Run a local LLM server (e.g. LocalAI, Ollama) exposing an OpenAI-compatible `/v1` endpoint.
+2. Replace the Anthropic Claude node with an OpenAI-compatible chat node pointing at your local server.
+3. Update the node's `model` value to your chosen local model (e.g. `llama3-8b-instruct`) and set the `baseUrl` option to the local endpoint.
+4. Update credentials in n8n to remove remote API keys and reference the local server instead.

--- a/docs/AI_Sub_Agent_Demo.md
+++ b/docs/AI_Sub_Agent_Demo.md
@@ -1,0 +1,20 @@
+# AI Sub Agent Demo
+
+## Overview
+- Demonstrates a hierarchy of sub-agents used to compose blog posts.
+- The main **Blog Writer Agent** orchestrates research, outline generation, writing and image creation.
+- Tools include Perplexity search, title/structure generation, section writing and image generation.
+- Relies on several OpenAI chat model nodes.
+
+## Flow
+1. **Research Agent** gathers information using Perplexity and other search tools.
+2. **Titles and Structure Tool** proposes titles and an outline.
+3. **Write Section Tool** drafts each section of the post.
+4. **Generate Image Tool** creates a matching graphic.
+5. Results are merged and returned by the **Blog Writer Agent**.
+
+## Switching to Local Models
+1. Spin up a local LLM endpoint compatible with the OpenAI API.
+2. Replace each OpenAI chat node with a local model (e.g. `llama3-8b` or `mixtral-8x7b`).
+3. Point the `baseUrl` option of the node to the local server and remove API keys.
+4. For image generation, use a local diffusion model or leave the API-based node as-is.

--- a/docs/AI_Sub_Agent_Demo.md
+++ b/docs/AI_Sub_Agent_Demo.md
@@ -1,20 +1,20 @@
-# AI Sub Agent Demo
+# Demonstracja podagentów
 
-## Overview
-- Demonstrates a hierarchy of sub-agents used to compose blog posts.
-- The main **Blog Writer Agent** orchestrates research, outline generation, writing and image creation.
-- Tools include Perplexity search, title/structure generation, section writing and image generation.
-- Relies on several OpenAI chat model nodes.
+## Przegląd
+- Pokazuje hierarchię podagentów używaną do tworzenia wpisów na blog.
+- Główny **Blog Writer Agent** koordynuje research, tworzenie konspektu, pisanie i generowanie obrazów.
+- Wykorzystuje narzędzia: wyszukiwanie Perplexity, tworzenie tytułu i struktury, pisanie sekcji oraz generowanie grafiki.
+- Opiera się na kilku węzłach z modelami OpenAI.
 
-## Flow
-1. **Research Agent** gathers information using Perplexity and other search tools.
-2. **Titles and Structure Tool** proposes titles and an outline.
-3. **Write Section Tool** drafts each section of the post.
-4. **Generate Image Tool** creates a matching graphic.
-5. Results are merged and returned by the **Blog Writer Agent**.
+## Przepływ
+1. **Research Agent** zbiera informacje z Perplexity i innych źródeł.
+2. **Titles and Structure Tool** proponuje tytuły i konspekt.
+3. **Write Section Tool** pisze każdą sekcję wpisu.
+4. **Generate Image Tool** tworzy pasującą grafikę.
+5. Wyniki łączy i zwraca **Blog Writer Agent**.
 
-## Switching to Local Models
-1. Spin up a local LLM endpoint compatible with the OpenAI API.
-2. Replace each OpenAI chat node with a local model (e.g. `llama3-8b` or `mixtral-8x7b`).
-3. Point the `baseUrl` option of the node to the local server and remove API keys.
-4. For image generation, use a local diffusion model or leave the API-based node as-is.
+## Przełączenie na modele lokalne
+1. Uruchom lokalny endpoint LLM zgodny z API OpenAI.
+2. Zamień każdy węzeł OpenAI na lokalny model (np. `llama3-8b` lub `mixtral-8x7b`).
+3. Ustaw opcję `baseUrl` w węźle na adres lokalnego serwera i usuń klucze API.
+4. Do generowania obrazów możesz użyć lokalnego modelu dyfuzyjnego albo pozostawić węzeł korzystający z zewnętrznego API.

--- a/docs/AI_Sub_Agent_Demo.md
+++ b/docs/AI_Sub_Agent_Demo.md
@@ -1,20 +1,28 @@
-# Demonstracja podagentów
+# Demo podagentów (jak zespół piszący bloga)
 
-## Przegląd
-- Pokazuje hierarchię podagentów używaną do tworzenia wpisów na blog.
-- Główny **Blog Writer Agent** koordynuje research, tworzenie konspektu, pisanie i generowanie obrazów.
-- Wykorzystuje narzędzia: wyszukiwanie Perplexity, tworzenie tytułu i struktury, pisanie sekcji oraz generowanie grafiki.
-- Opiera się na kilku węzłach z modelami OpenAI.
+## O co chodzi?
+Wyobraź sobie redakcję. Redaktor naczelny prosi kilku reporterów o pomoc:
+jednego o research, innego o napisanie tytułów, kolejnego o napisanie
+paragrafów, a jeszcze innego o znalezienie obrazka. Ten workflow pokazuje, jak
+taka współpraca wygląda w n8n.
 
-## Przepływ
-1. **Research Agent** zbiera informacje z Perplexity i innych źródeł.
-2. **Titles and Structure Tool** proponuje tytuły i konspekt.
-3. **Write Section Tool** pisze każdą sekcję wpisu.
-4. **Generate Image Tool** tworzy pasującą grafikę.
-5. Wyniki łączy i zwraca **Blog Writer Agent**.
+## Kto tu pracuje
+- **Blog Writer Agent** – redaktor naczelny, który scala wszystko w jedną całość.
+- **Research Agent** – reporter zbierający informacje z internetu.
+- **Titles and Structure Tool** – pomaga ułożyć tytuł i plan artykułu.
+- **Write Section Tool** – pisze każdy akapit.
+- **Generate Image Tool** – dobiera grafikę pasującą do tekstu.
 
-## Przełączenie na modele lokalne
-1. Uruchom lokalny endpoint LLM zgodny z API OpenAI.
-2. Zamień każdy węzeł OpenAI na lokalny model (np. `llama3-8b` lub `mixtral-8x7b`).
-3. Ustaw opcję `baseUrl` w węźle na adres lokalnego serwera i usuń klucze API.
-4. Do generowania obrazów możesz użyć lokalnego modelu dyfuzyjnego albo pozostawić węzeł korzystający z zewnętrznego API.
+## Jak przetestować
+1. Zaimportuj w n8n plik `AI Sub Agent Demo.json`.
+2. Ustaw lokalny model zgodnie z poradnikiem
+   [Local_LLM_Setup.md](Local_LLM_Setup.md) – w każdym węźle wybierz `Local
+   OpenAI` i odpowiedni model.
+3. Kliknij **Execute Workflow** i w czacie poproś: „Napisz artykuł o zdrowym
+   śnie”. Zobaczysz, jak kolejne narzędzia kolejno się uruchamiają.
+
+## Co możesz zmienić
+- Zamień modele na inne (np. `mixtral-8x7b` zamiast `llama3-8b`).
+- Podłącz własne źródła danych do Research Agenta.
+- Dodaj dodatkowy krok, np. korektę języka przez **Bielika**.
+

--- a/docs/Deep_Research_Agent.md
+++ b/docs/Deep_Research_Agent.md
@@ -1,17 +1,17 @@
-# Deep Research Agent
+# Agent głębokiego researchu
 
-## Overview
-- Specialised in deep research using Perplexity's Sonar and Sonar Pro models.
-- Central `AI Agent` (OpenAI GPT-4o-mini) decides when to call each Perplexity tool.
-- Includes a `Window Buffer Memory` node to retain recent dialogue.
-- Designed for Telegram integration with an access filter.
+## Przegląd
+- Specjalizuje się w głębokim researchu z użyciem modeli Sonar i Sonar Pro od Perplexity.
+- Centralny `AI Agent` (OpenAI GPT-4o-mini) decyduje, kiedy wywołać odpowiednie narzędzie Perplexity.
+- Zawiera węzeł `Window Buffer Memory`, który przechowuje niedawny kontekst rozmowy.
+- Zaprojektowany z myślą o integracji z Telegramem i filtrem dostępu.
 
-## Flow
-1. User message arrives via Telegram and passes through an access `Filter`.
-2. The `AI Agent` analyses the query and chooses between Sonar and Sonar Pro tools.
-3. The chosen tool returns data which the agent summarises for the user.
+## Przepływ
+1. Wiadomość użytkownika dociera przez Telegram i przechodzi przez `Filter`, który sprawdza uprawnienia.
+2. `AI Agent` analizuje zapytanie i wybiera narzędzie Sonar lub Sonar Pro.
+3. Wybrane narzędzie zwraca dane, które agent streszcza dla użytkownika.
 
-## Switching to Local Models
-1. Replace the main OpenAI model with a local LLM via an OpenAI-compatible chat node.
-2. If Perplexity access is not desired, substitute the Sonar tools with local web-search or RAG tools.
-3. Update credentials to reference the local endpoint and remove API keys.
+## Przełączenie na modele lokalne
+1. Zamień główny model OpenAI na lokalny LLM, korzystając z węzła kompatybilnego z OpenAI.
+2. Jeśli nie chcesz używać Perplexity, zastąp narzędzia Sonar lokalnym wyszukiwaniem internetowym lub RAG.
+3. Zaktualizuj poświadczenia tak, aby wskazywały na lokalny endpoint i usuń klucze API.

--- a/docs/Deep_Research_Agent.md
+++ b/docs/Deep_Research_Agent.md
@@ -1,0 +1,17 @@
+# Deep Research Agent
+
+## Overview
+- Specialised in deep research using Perplexity's Sonar and Sonar Pro models.
+- Central `AI Agent` (OpenAI GPT-4o-mini) decides when to call each Perplexity tool.
+- Includes a `Window Buffer Memory` node to retain recent dialogue.
+- Designed for Telegram integration with an access filter.
+
+## Flow
+1. User message arrives via Telegram and passes through an access `Filter`.
+2. The `AI Agent` analyses the query and chooses between Sonar and Sonar Pro tools.
+3. The chosen tool returns data which the agent summarises for the user.
+
+## Switching to Local Models
+1. Replace the main OpenAI model with a local LLM via an OpenAI-compatible chat node.
+2. If Perplexity access is not desired, substitute the Sonar tools with local web-search or RAG tools.
+3. Update credentials to reference the local endpoint and remove API keys.

--- a/docs/Deep_Research_Agent.md
+++ b/docs/Deep_Research_Agent.md
@@ -1,17 +1,27 @@
-# Agent głębokiego researchu
+# Agent głębokiego researchu (internetowy detektyw)
 
-## Przegląd
-- Specjalizuje się w głębokim researchu z użyciem modeli Sonar i Sonar Pro od Perplexity.
-- Centralny `AI Agent` (OpenAI GPT-4o-mini) decyduje, kiedy wywołać odpowiednie narzędzie Perplexity.
-- Zawiera węzeł `Window Buffer Memory`, który przechowuje niedawny kontekst rozmowy.
-- Zaprojektowany z myślą o integracji z Telegramem i filtrem dostępu.
+## Co to jest?
+Gdy potrzebujesz odpowiedzi na trudne pytania, ten agent działa jak
+dociekliwy detektyw. Potrafi przeszukiwać internet i zbierać informacje z
+różnych źródeł, po czym streszcza je w prosty sposób.
 
-## Przepływ
-1. Wiadomość użytkownika dociera przez Telegram i przechodzi przez `Filter`, który sprawdza uprawnienia.
-2. `AI Agent` analizuje zapytanie i wybiera narzędzie Sonar lub Sonar Pro.
-3. Wybrane narzędzie zwraca dane, które agent streszcza dla użytkownika.
+## Jak wygląda śledztwo
+1. **Wiadomość z Telegrama** – pytasz np. „Jak działa energia słoneczna?”.
+2. **Filter** – upewnia się, że masz dostęp do agenta.
+3. **AI Agent** – decyduje, czy wystarczy szybkie wyszukiwanie (Sonar) czy
+   potrzebne jest głębsze kopanie (Sonar Pro).
+4. **Streszczenie** – agent zbiera znalezione informacje i odsyła zwięzłą
+   odpowiedź.
 
-## Przełączenie na modele lokalne
-1. Zamień główny model OpenAI na lokalny LLM, korzystając z węzła kompatybilnego z OpenAI.
-2. Jeśli nie chcesz używać Perplexity, zastąp narzędzia Sonar lokalnym wyszukiwaniem internetowym lub RAG.
-3. Zaktualizuj poświadczenia tak, aby wskazywały na lokalny endpoint i usuń klucze API.
+## Jak uruchomić
+1. Zaimportuj `Deep_Research_Agent.json` do n8n.
+2. W węźle z modelem ustaw lokalny LLM (np. `qwen2-7b`) według
+   [Local_LLM_Setup.md](Local_LLM_Setup.md).
+3. Jeśli nie chcesz korzystać z usług Perplexity, podłącz własne źródło danych
+   lub prosty RAG.
+4. Kliknij **Execute Workflow** i zadawaj pytania w okienku czatu.
+
+## Podpowiedź
+Możesz rozszerzyć agenta, aby zapisywał najciekawsze znaleziska w notatniku lub
+wysyłał je e‑mailem do ciebie.
+

--- a/docs/Deep_Research_V2_RAG.md
+++ b/docs/Deep_Research_V2_RAG.md
@@ -1,17 +1,27 @@
-# Agent głębokiego researchu V2 + RAG
+# Agent researchu V2 z własnym notesem (RAG)
 
-## Przegląd
-- Zaawansowany agent researchowy łączący wyszukiwanie w sieci z Retrieval-Augmented Generation.
-- Wykorzystuje Supabase jako wektorową bazę wiedzy.
-- Zawiera węzły do wczytywania plików PDF i dzielenia tekstu, aby zasilać bazę.
-- Wykorzystuje modele DeepSeek do rozumowania.
+## Co go wyróżnia?
+To jak detektyw, który oprócz internetu ma własny uporządkowany notes. Notesem
+jest baza Supabase, gdzie można wrzucać dokumenty (np. PDF) i później szybko je
+odnajdywać.
 
-## Przepływ
-1. Wyzwalacz Telegrama przekazuje wiadomości do `Switch`, który wybiera odpowiedni tryb agenta.
-2. Dokumenty można przesłać, podzielić i zembedować w Supabase, aby później je wyszukiwać.
-3. `AI Agent` odpyta wektorową bazę i narzędzia zewnętrzne, aby przygotować wyczerpującą odpowiedź.
+## Jak przebiega praca
+1. **Telegram Trigger** – odbiera pytania lub dokumenty.
+2. **Split & Embed** – jeśli wyślesz plik, agent dzieli go na małe kawałki i
+   zapisuje w bazie Supabase.
+3. **AI Agent** – gdy zadasz pytanie, agent sięga do internetu i do swojego
+   „notesu”, aby skleić pełną odpowiedź.
 
-## Przełączenie na modele lokalne
-1. Zamień węzły DeepSeek na lokalne modele działające na endpointzie zgodnym z OpenAI.
-2. Do embeddingów użyj lokalnego modelu lub usługi offline współpracującej z Supabase.
-3. Upewnij się, że wszystkie poświadczenia wskazują na lokalne usługi i nie zawierają zdalnych kluczy.
+## Uruchomienie krok po kroku
+1. W n8n zaimportuj plik `Deep_Research_V2___RAG.json`.
+2. Zgodnie z [Local_LLM_Setup.md](Local_LLM_Setup.md) ustaw lokalny model (np.
+   `qwen2-7b`) we wszystkich węzłach LLM.
+3. Ustaw połączenie z bazą Supabase (adres, klucz API). W tutorialach Supabase
+   znajdziesz darmową wersję do testów.
+4. Kliknij **Execute Workflow** i spróbuj wysłać plik PDF oraz pytanie na jego
+   temat.
+
+## Dalsze pomysły
+- Możesz dodać przeszukiwanie własnego folderu z notatkami.
+- Zastąp Supabase inną bazą wektorową, jeśli wolisz (np. Chroma).
+

--- a/docs/Deep_Research_V2_RAG.md
+++ b/docs/Deep_Research_V2_RAG.md
@@ -1,17 +1,17 @@
-# Deep Research V2 + RAG
+# Agent głębokiego researchu V2 + RAG
 
-## Overview
-- Advanced research agent combining web search with Retrieval-Augmented Generation.
-- Utilises Supabase as a vector store for document retrieval.
-- Includes PDF ingestion and text splitting nodes to populate the knowledge base.
-- Employs DeepSeek chat models for reasoning.
+## Przegląd
+- Zaawansowany agent researchowy łączący wyszukiwanie w sieci z Retrieval-Augmented Generation.
+- Wykorzystuje Supabase jako wektorową bazę wiedzy.
+- Zawiera węzły do wczytywania plików PDF i dzielenia tekstu, aby zasilać bazę.
+- Wykorzystuje modele DeepSeek do rozumowania.
 
-## Flow
-1. A Telegram trigger forwards user messages to a `Switch` that selects the desired agent mode.
-2. Documents can be uploaded, split and embedded into Supabase for later retrieval.
-3. The `AI Agent` queries the vector store and external tools to craft a comprehensive answer.
+## Przepływ
+1. Wyzwalacz Telegrama przekazuje wiadomości do `Switch`, który wybiera odpowiedni tryb agenta.
+2. Dokumenty można przesłać, podzielić i zembedować w Supabase, aby później je wyszukiwać.
+3. `AI Agent` odpyta wektorową bazę i narzędzia zewnętrzne, aby przygotować wyczerpującą odpowiedź.
 
-## Switching to Local Models
-1. Swap the DeepSeek chat nodes with local models hosted on an OpenAI-style endpoint.
-2. For embeddings, use a local embedding model or an offline service compatible with Supabase.
-3. Ensure all credential nodes point to the local services and remove remote keys.
+## Przełączenie na modele lokalne
+1. Zamień węzły DeepSeek na lokalne modele działające na endpointzie zgodnym z OpenAI.
+2. Do embeddingów użyj lokalnego modelu lub usługi offline współpracującej z Supabase.
+3. Upewnij się, że wszystkie poświadczenia wskazują na lokalne usługi i nie zawierają zdalnych kluczy.

--- a/docs/Deep_Research_V2_RAG.md
+++ b/docs/Deep_Research_V2_RAG.md
@@ -1,0 +1,17 @@
+# Deep Research V2 + RAG
+
+## Overview
+- Advanced research agent combining web search with Retrieval-Augmented Generation.
+- Utilises Supabase as a vector store for document retrieval.
+- Includes PDF ingestion and text splitting nodes to populate the knowledge base.
+- Employs DeepSeek chat models for reasoning.
+
+## Flow
+1. A Telegram trigger forwards user messages to a `Switch` that selects the desired agent mode.
+2. Documents can be uploaded, split and embedded into Supabase for later retrieval.
+3. The `AI Agent` queries the vector store and external tools to craft a comprehensive answer.
+
+## Switching to Local Models
+1. Swap the DeepSeek chat nodes with local models hosted on an OpenAI-style endpoint.
+2. For embeddings, use a local embedding model or an offline service compatible with Supabase.
+3. Ensure all credential nodes point to the local services and remove remote keys.

--- a/docs/Local_LLM_Setup.md
+++ b/docs/Local_LLM_Setup.md
@@ -1,4 +1,4 @@
-# Local LLM Setup Guide
+# Przewodnik konfiguracji lokalnych modeli LLM
 
 ## 1. Co będziemy robić
 Ten poradnik pokazuje, jak uruchomić agentów z tego repozytorium na własnym komputerze

--- a/docs/Local_LLM_Setup.md
+++ b/docs/Local_LLM_Setup.md
@@ -1,0 +1,53 @@
+# Local LLM Setup Guide
+
+## 1. Co będziemy robić
+Ten poradnik pokazuje, jak uruchomić agentów z tego repozytorium na własnym komputerze
+bez internetu. Wszystko opisane jest prostym językiem, aby nawet początkujący mogli
+spróbować swoich sił.
+
+## 2. Czego potrzebujemy
+1. **Komputer z mocną kartą graficzną** – Twój sprzęt z RTX 5080 i 32 GB RAM świetnie się nadaje.
+2. **Program do uruchamiania modeli** – użyjemy [LM Studio](https://lmstudio.ai) (łatwy interfejs) lub [Ollama](https://ollama.com) (działa z terminala).
+3. **n8n** – tutaj działają wszystkie agentowe "przepisy". Możesz skorzystać z wersji Desktop [z tej strony](https://n8n.io).
+
+## 3. Pobieranie modeli
+### 3.1 Otwórz LM Studio
+1. Uruchom LM Studio i przejdź do zakładki **Models**.
+2. Wpisz nazwę modelu w wyszukiwarkę i kliknij **Download**.
+
+### 3.2 Jakie modele pobrać
+| Zastosowanie | Nazwa modelu w LM Studio | Do czego służy |
+|-------------|-------------------------|---------------|
+| Główny mózg asystenta | `mixtral-8x7b-instruct` | rozumienie pytań i sterowanie innymi agentami |
+| Szybkie zadania (np. pogoda) | `phi-3-mini` | krótkie odpowiedzi, działa błyskawicznie |
+| Głęboki research | `qwen2-7b-instruct` | analizuje i łączy informacje |
+| Piękny język polski | `bielik-11b` | tłumaczenia i poprawa stylu |
+| Transkrypcja audio | `faster-whisper-large-v3` | zamienia mowę na tekst |
+
+> Jeśli model jest zbyt duży, w LM Studio wybierz opcję **Quantized** (np. 4-bit), wtedy zmieści się w pamięci karty graficznej.
+
+## 4. Uruchomienie lokalnego serwera modeli
+1. W LM Studio przejdź do zakładki **Server**.
+2. Kliknij **Start** – pojawi się adres, np. `http://localhost:8080`.
+3. Zanotuj ten adres; w n8n ustawimy go jako "OpenAI Base URL".
+
+## 5. Podłączenie modeli w n8n
+1. Uruchom n8n i zaimportuj workflow, np. `Personal Assistant.json`.
+2. Wejdź w zakładkę **Credentials** → **OpenAI** → dodaj nowe i nazwij je `Local OpenAI`.
+3. W polu **Base URL** wpisz `http://localhost:8080/v1`, a pole z kluczem API zostaw puste.
+4. Otwórz węzeł z modelem (np. `GPT-4.1`) i wybierz w nim poświadczenia `Local OpenAI`. Zmień nazwę modelu na taką, jak w LM Studio (np. `mixtral-8x7b-instruct`).
+5. Powtórz dla pozostałych węzłów: research (`qwen2-7b-instruct`), szybkie zadania (`phi-3-mini`), tłumaczenia (`bielik-11b`).
+6. Dla transkrypcji głosu dodaj węzeł **HTTP Request** kierujący na `faster-whisper`.
+
+## 6. Korzystanie z agentów
+1. W n8n kliknij **Execute Workflow**.
+2. Otwórz Telegram i wyślij wiadomość do bota powiązanego z `Personal Assistant`.
+3. Zadawaj pytania po polsku. Asystent sam dobierze model i odpowie.
+4. Spróbuj też innych agentów z folderu `docs/` – każdy działa podobnie, tylko ma inne zadania (np. zarządzanie projektami, tworzenie blogów).
+
+## 7. Co dalej
+- Testuj różne modele. Jeśli odpowiedzi są wolne, wybierz mniejszy model.
+- Zajrzyj do plików `docs/*.md` aby dowiedzieć się, co robi każdy agent.
+- Ucz się poprzez zabawę – modyfikuj workflowy i zobacz, co się stanie!
+
+Powodzenia i miłej nauki!

--- a/docs/Personal_Assistant.md
+++ b/docs/Personal_Assistant.md
@@ -1,0 +1,25 @@
+# Personal Assistant
+
+## Overview
+- Telegram-based assistant orchestrating multiple specialised agents.
+- Handles text and voice input, research, finance tracking, email management, weather/news and content writing.
+- Maintains long-term context using Postgres-backed chat memory.
+
+## Flow
+1. **Telegram Trigger** receives user messages or audio.
+2. Audio is transcribed and merged with text in `Combine fields`.
+3. The **Orchestrator Agent** selects sub-agents such as Research, Finance Tracker, Email Manager or Write Section Tool.
+4. Responses are sent back through Telegram.
+
+## Local Model Integration
+- Replaced remote models with locally hosted equivalents:
+  - **GPT-4.1** → `mixtral-8x7b` at `http://localhost:8080/v1`.
+  - **Anthropic Chat Model** → `qwen2-7b-instruct` via the same local endpoint.
+  - **GPT-5-Nano** → `phi-3-mini` for lightweight tasks.
+  - **OpenAI** transcription → `faster-whisper` running locally.
+- All LLM nodes now reference credentials named **Local OpenAI** pointing to the local server.
+- These changes allow the entire assistant workflow to operate without external API calls.
+
+## Further Enhancements
+- Insert a translation layer using a Polish model such as **Bielik 11B** to ensure natural language output.
+- Swap remaining OpenAI tool nodes for self-hosted alternatives as needed.

--- a/docs/Personal_Assistant.md
+++ b/docs/Personal_Assistant.md
@@ -1,25 +1,25 @@
-# Personal Assistant
+# Asystent osobisty
 
-## Overview
-- Telegram-based assistant orchestrating multiple specialised agents.
-- Handles text and voice input, research, finance tracking, email management, weather/news and content writing.
-- Maintains long-term context using Postgres-backed chat memory.
+## Przegląd
+- Asystent działający przez Telegram, który koordynuje wiele wyspecjalizowanych agentów.
+- Obsługuje tekst i głos, research, śledzenie wydatków, zarządzanie e‑mailami, pogodę/wiadomości oraz pisanie treści.
+- Utrzymuje długoterminowy kontekst dzięki pamięci czatu opartej na Postgresie.
 
-## Flow
-1. **Telegram Trigger** receives user messages or audio.
-2. Audio is transcribed and merged with text in `Combine fields`.
-3. The **Orchestrator Agent** selects sub-agents such as Research, Finance Tracker, Email Manager or Write Section Tool.
-4. Responses are sent back through Telegram.
+## Przepływ
+1. **Telegram Trigger** odbiera wiadomości lub nagrania.
+2. Nagrania są transkrybowane i łączone z tekstem w `Combine fields`.
+3. **Orchestrator Agent** wybiera podagentów, takich jak Research, Finance Tracker, Email Manager czy Write Section Tool.
+4. Odpowiedzi wracają do użytkownika przez Telegram.
 
-## Local Model Integration
-- Replaced remote models with locally hosted equivalents:
-  - **GPT-4.1** → `mixtral-8x7b` at `http://localhost:8080/v1`.
-  - **Anthropic Chat Model** → `qwen2-7b-instruct` via the same local endpoint.
-  - **GPT-5-Nano** → `phi-3-mini` for lightweight tasks.
-  - **OpenAI** transcription → `faster-whisper` running locally.
-- All LLM nodes now reference credentials named **Local OpenAI** pointing to the local server.
-- These changes allow the entire assistant workflow to operate without external API calls.
+## Integracja z modelami lokalnymi
+- Zastąpiono zdalne modele lokalnymi odpowiednikami:
+  - **GPT-4.1** → `mixtral-8x7b` działający pod `http://localhost:8080/v1`.
+  - **Anthropic Chat Model** → `qwen2-7b-instruct` pod tym samym adresem.
+  - **GPT-5-Nano** → `phi-3-mini` do lekkich zadań.
+  - **OpenAI** (transkrypcja) → lokalny `faster-whisper`.
+- Wszystkie węzły LLM korzystają z poświadczeń **Local OpenAI** wskazujących na lokalny serwer.
+- Dzięki temu cały workflow asystenta działa bez zewnętrznych wywołań API.
 
-## Further Enhancements
-- Insert a translation layer using a Polish model such as **Bielik 11B** to ensure natural language output.
-- Swap remaining OpenAI tool nodes for self-hosted alternatives as needed.
+## Dalsze usprawnienia
+- Można dodać warstwę tłumaczenia z użyciem modelu **Bielik 11B**, aby zadbać o naturalną polszczyznę.
+- W razie potrzeby zastąp pozostałe węzły OpenAI odpowiednikami hostowanymi lokalnie.

--- a/docs/Personal_Assistant.md
+++ b/docs/Personal_Assistant.md
@@ -1,25 +1,52 @@
-# Asystent osobisty
+# Asystent osobisty (jak przyjaciel, który pamięta wszystko)
 
-## Przegląd
-- Asystent działający przez Telegram, który koordynuje wiele wyspecjalizowanych agentów.
-- Obsługuje tekst i głos, research, śledzenie wydatków, zarządzanie e‑mailami, pogodę/wiadomości oraz pisanie treści.
-- Utrzymuje długoterminowy kontekst dzięki pamięci czatu opartej na Postgresie.
+## Co robi?
+Wyobraź sobie, że masz drużynę małych pomocników. Jeden zna się na pogodzie,
+drugi pilnuje wydatków, a trzeci potrafi pisać maile. Nad nimi czuwa
+**Dyrygent** – Orchestrator. Kiedy wysyłasz wiadomość, Dyrygent decyduje, którego
+pomocnika poprosić o działanie i łączy odpowiedzi w jedną wiadomość.
 
-## Przepływ
-1. **Telegram Trigger** odbiera wiadomości lub nagrania.
-2. Nagrania są transkrybowane i łączone z tekstem w `Combine fields`.
-3. **Orchestrator Agent** wybiera podagentów, takich jak Research, Finance Tracker, Email Manager czy Write Section Tool.
-4. Odpowiedzi wracają do użytkownika przez Telegram.
+## Jak działa w środku
+1. **Wiadomość z Telegrama** – piszesz tekst albo nagrywasz głos.
+2. **Transkrypcja** – jeśli to nagranie, „maszyna do pisania” (Whisper) zamienia
+   głos na tekst.
+3. **Dyrygent** – Orchestrator czyta tekst i wybiera odpowiedniego pomocnika:
+   - *Badacz* szuka informacji w sieci,
+   - *Księgowy* zapisuje wydatki,
+   - *Sekretarz* tworzy lub streszcza e‑maile,
+   - *Pisarz* tworzy dłuższe teksty.
+4. **Powrót odpowiedzi** – wynik wraca do ciebie na Telegramie.
 
-## Integracja z modelami lokalnymi
-- Zastąpiono zdalne modele lokalnymi odpowiednikami:
-  - **GPT-4.1** → `mixtral-8x7b` działający pod `http://localhost:8080/v1`.
-  - **Anthropic Chat Model** → `qwen2-7b-instruct` pod tym samym adresem.
-  - **GPT-5-Nano** → `phi-3-mini` do lekkich zadań.
-  - **OpenAI** (transkrypcja) → lokalny `faster-whisper`.
-- Wszystkie węzły LLM korzystają z poświadczeń **Local OpenAI** wskazujących na lokalny serwer.
-- Dzięki temu cały workflow asystenta działa bez zewnętrznych wywołań API.
+## Jak uruchomić agenta krok po kroku
+1. **Przygotuj modele** – postępuj według poradnika
+   [Local_LLM_Setup.md](Local_LLM_Setup.md). Pobierz np. `mixtral-8x7b` i
+   `phi-3-mini`, uruchom serwer w LM Studio.
+2. **Włącz n8n** – pobierz wersję Desktop, włącz i kliknij **Import**, aby
+   wczytać plik `Personal Assistant.json`.
+3. **Połącz z modelami**
+   - Wejdź w **Credentials → OpenAI → Add** i nazwij połączenie `Local OpenAI`.
+   - W polu **Base URL** wpisz adres serwera z LM Studio, np.
+     `http://localhost:8080/v1`. Pole z kluczem pozostaw puste.
+   - Otwórz każdy węzeł LLM (np. `GPT‑4.1`) i wybierz połączenie `Local OpenAI`,
+     a w polu model wpisz nazwę pobranego modelu.
+4. **Skonfiguruj Telegram** – w aplikacji Telegram napisz do `@BotFather`,
+   utwórz nowego bota i skopiuj token. W n8n w węźle `Telegram Trigger` wklej
+   ten token.
+5. **Start** – kliknij **Execute Workflow** i napisz do swojego bota na
+   Telegramie. Powinieneś otrzymać odpowiedź od Asystenta.
 
-## Dalsze usprawnienia
-- Można dodać warstwę tłumaczenia z użyciem modelu **Bielik 11B**, aby zadbać o naturalną polszczyznę.
-- W razie potrzeby zastąp pozostałe węzły OpenAI odpowiednikami hostowanymi lokalnie.
+## Przykładowa rozmowa
+```
+Ty: "Dodaj wydatek 15 zł na kawę"
+Asystent: "Zapisano: kawa – 15 zł"
+
+Ty: "A jaka jutro będzie pogoda w Warszawie?"
+Asystent: "Jutro 12 °C i deszcz, nie zapomnij parasola!"
+```
+
+## Jak rozwijać dalej
+- Dodaj tłumacza **Bielik**, aby odpowiedzi brzmiały jeszcze naturalniej po
+  polsku.
+- Napisz własnego pomocnika, np. do planowania diety – Dyrygent zajmie się jego
+  włączeniem w rozmowę.
+

--- a/docs/Second_Brain_Agent.md
+++ b/docs/Second_Brain_Agent.md
@@ -1,17 +1,17 @@
-# Second Brain Agent
+# Agent Drugiego Mózgu
 
-## Overview
-- Acts as a personal knowledge base using Supabase for vector storage.
-- The `Vector Store Agent` powered by OpenAI GPT-4o-mini handles add/search operations.
-- Conversation context is saved in Postgres via `Postgres Chat Memory`.
-- Integrations include Telegram and YouTube transcription to ingest content.
+## Przegląd
+- Działa jako osobista baza wiedzy, wykorzystując Supabase do przechowywania wektorów.
+- `Vector Store Agent` oparty na OpenAI GPT-4o-mini dodaje i wyszukuje informacje.
+- Kontekst rozmowy przechowywany jest w Postgresie przez `Postgres Chat Memory`.
+- Integracje obejmują Telegram oraz transkrypcję YouTube do wprowadzania treści.
 
-## Flow
-1. Incoming data is embedded and stored in Supabase.
-2. User queries trigger retrieval from the vector store.
-3. The agent composes responses using retrieved context and returns them to the user.
+## Przepływ
+1. Napływające dane są embedowane i zapisywane w Supabase.
+2. Zapytania użytkownika uruchamiają wyszukiwanie wektorowe.
+3. Agent tworzy odpowiedź na podstawie znalezionych fragmentów i odsyła ją użytkownikowi.
 
-## Switching to Local Models
-1. Replace GPT-4o-mini with a local LLM (e.g. `llama3-8b`), updating the node's model and `baseUrl`.
-2. Swap OpenAI embeddings with a local embedding model such as `text-embedding-nomic`.
-3. Update credentials to remove remote API keys and reference the local endpoints.
+## Przełączenie na modele lokalne
+1. Zamień GPT-4o-mini na lokalny LLM (np. `llama3-8b`), aktualizując model i `baseUrl` w węźle.
+2. Wymień embeddingi OpenAI na lokalny model, np. `text-embedding-nomic`.
+3. Zaktualizuj poświadczenia, aby usuwały zdalne klucze API i kierowały zapytania na lokalne endpointy.

--- a/docs/Second_Brain_Agent.md
+++ b/docs/Second_Brain_Agent.md
@@ -1,0 +1,17 @@
+# Second Brain Agent
+
+## Overview
+- Acts as a personal knowledge base using Supabase for vector storage.
+- The `Vector Store Agent` powered by OpenAI GPT-4o-mini handles add/search operations.
+- Conversation context is saved in Postgres via `Postgres Chat Memory`.
+- Integrations include Telegram and YouTube transcription to ingest content.
+
+## Flow
+1. Incoming data is embedded and stored in Supabase.
+2. User queries trigger retrieval from the vector store.
+3. The agent composes responses using retrieved context and returns them to the user.
+
+## Switching to Local Models
+1. Replace GPT-4o-mini with a local LLM (e.g. `llama3-8b`), updating the node's model and `baseUrl`.
+2. Swap OpenAI embeddings with a local embedding model such as `text-embedding-nomic`.
+3. Update credentials to remove remote API keys and reference the local endpoints.

--- a/docs/Second_Brain_Agent.md
+++ b/docs/Second_Brain_Agent.md
@@ -1,17 +1,28 @@
-# Agent Drugiego Mózgu
+# Agent Drugiego Mózgu (twój osobisty bibliotekarz)
 
-## Przegląd
-- Działa jako osobista baza wiedzy, wykorzystując Supabase do przechowywania wektorów.
-- `Vector Store Agent` oparty na OpenAI GPT-4o-mini dodaje i wyszukuje informacje.
-- Kontekst rozmowy przechowywany jest w Postgresie przez `Postgres Chat Memory`.
-- Integracje obejmują Telegram oraz transkrypcję YouTube do wprowadzania treści.
+## Idea
+Zamiast trzymać ważne informacje w głowie, możesz je odkładać do „drugiego
+mózgu”. Agent zapisuje notatki w bazie Supabase i potrafi je później znaleźć,
+gdy o coś zapytasz.
 
-## Przepływ
-1. Napływające dane są embedowane i zapisywane w Supabase.
-2. Zapytania użytkownika uruchamiają wyszukiwanie wektorowe.
-3. Agent tworzy odpowiedź na podstawie znalezionych fragmentów i odsyła ją użytkownikowi.
+## Jak to działa
+1. **Dodawanie informacji** – wysyłasz wiadomość lub plik. Agent tworzy z niego
+   wektor i zapisuje w bazie (jak spis treści w bibliotece).
+2. **Pytanie** – prosisz: „Przypomnij mi ciekawostki o Marsie”.
+3. **Wyszukiwanie** – agent przeszukuje bazę i zwraca pasujące fragmenty.
+4. **Odpowiedź** – z odnalezionych notatek tworzy krótkie podsumowanie.
 
-## Przełączenie na modele lokalne
-1. Zamień GPT-4o-mini na lokalny LLM (np. `llama3-8b`), aktualizując model i `baseUrl` w węźle.
-2. Wymień embeddingi OpenAI na lokalny model, np. `text-embedding-nomic`.
-3. Zaktualizuj poświadczenia, aby usuwały zdalne klucze API i kierowały zapytania na lokalne endpointy.
+## Uruchomienie krok po kroku
+1. Zaimportuj w n8n `Second_Brain_Agent.json`.
+2. Skonfiguruj połączenie z Supabase (adres i klucz). Możesz użyć darmowego
+   konta.
+3. Ustaw lokalny model LLM oraz embeddings zgodnie z
+   [Local_LLM_Setup.md](Local_LLM_Setup.md) – np. `llama3-8b` i
+   `text-embedding-nomic`.
+4. Kliknij **Execute Workflow**. Dodaj kilka notatek i spróbuj o nie zapytać.
+
+## Pomysły na rozwój
+- Połącz agenta z YouTube lub podcastami, aby automatycznie zapisywać
+  transkrypcje.
+- Dodaj funkcję przypomnień wysyłanych na e‑mail.
+


### PR DESCRIPTION
## Summary
- document key agent workflows and how to adapt them for local models
- configure Personal Assistant workflow to use local LLMs and local Whisper
- add beginner-friendly guide for downloading and running local models

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_b_68a75f85d294832dbe7bbf1aa0dec99c