### PR TITLE
docs: outline agents and switch personal assistant to local llms

### DIFF
--- a/Personal Assistant.json
+++ b/Personal Assistant.json
@@ -279,12 +279,14 @@
         "model": {
           "__rl": true,
           "mode": "list",
-          "value": "claude-sonnet-4-20250514",
+          "value": "qwen2-7b-instruct",
           "cachedResultName": "Claude 4 Sonnet"
         },
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        }
       },
-      "type": "@n8n/n8n-nodes-langchain.lmChatAnthropic",
+      "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.3,
       "position": [
         -832,
@@ -293,9 +295,9 @@
       "id": "f60bc37c-4c92-4975-b578-13f04f174fce",
       "name": "Anthropic Chat Model",
       "credentials": {
-        "anthropicApi": {
-          "id": "KztKfqsNjNkkJM89",
-          "name": "Anthropic account"
+        "openAiApi": {
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },
@@ -627,11 +629,13 @@
       "parameters": {
         "model": {
           "__rl": true,
-          "value": "gpt-4.1-mini",
+          "value": "phi-3-mini",
           "mode": "list",
           "cachedResultName": "gpt-4.1-mini"
         },
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        }
       },
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.2,
@@ -643,8 +647,8 @@
       "name": "GPT-5-Nano",
       "credentials": {
         "openAiApi": {
-          "id": "ybRg3lag38rmtn5D",
-          "name": "Shab OpenAi account"
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },
@@ -2313,7 +2317,10 @@
       "parameters": {
         "resource": "audio",
         "operation": "transcribe",
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        },
+        "model": "faster-whisper"
       },
       "type": "@n8n/n8n-nodes-langchain.openAi",
       "typeVersion": 1.8,
@@ -2325,8 +2332,8 @@
       "name": "OpenAI",
       "credentials": {
         "openAiApi": {
-          "id": "ybRg3lag38rmtn5D",
-          "name": "Shab OpenAi account"
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },
@@ -2501,11 +2508,13 @@
       "parameters": {
         "model": {
           "__rl": true,
-          "value": "gpt-4.1",
+          "value": "mixtral-8x7b",
           "mode": "list",
           "cachedResultName": "gpt-4.1"
         },
-        "options": {}
+        "options": {
+          "baseUrl": "http://localhost:8080/v1"
+        }
       },
       "type": "@n8n/n8n-nodes-langchain.lmChatOpenAi",
       "typeVersion": 1.2,
@@ -2517,8 +2526,8 @@
       "name": "GPT-4.1",
       "credentials": {
         "openAiApi": {
-          "id": "ybRg3lag38rmtn5D",
-          "name": "Shab OpenAi account"
+          "id": "local-openai",
+          "name": "Local OpenAI"
         }
       }
     },

--- a/docs/AI_Project_Management.md
+++ b/docs/AI_Project_Management.md
@@ -1,0 +1,28 @@
+# Agent zarządzania projektami (jak kierownik w Asanie)
+
+## Co robi?
+Wyobraź sobie kierownika, któremu mówisz „zrób projekt” i on od razu tworzy go
+w Asanie. Ten agent słucha twoich poleceń na czacie i wykonuje je w Asanie:
+dodaje projekty, zadania, a nawet podzadania.
+
+## Jak działa
+1. **Piszesz polecenie** – np. „Stwórz projekt Strona WWW”.
+2. **Agent Project Manager** rozumie, o co prosisz i wybiera odpowiednią akcję w
+   Asanie.
+3. **Simple Memory** zapamiętuje rozmowę, więc agent pamięta, nad czym
+   pracujecie.
+4. **Think** pomaga mu lepiej zrozumieć złożone instrukcje.
+
+## Jak uruchomić
+1. W n8n kliknij **Import** i wybierz plik `AI Project Management.json`.
+2. W zakładce **Credentials** dodaj klucz API do Asany.
+3. Węzeł z modelem LLM ustaw na lokalny, zgodnie z poradnikiem
+   [Local_LLM_Setup.md](Local_LLM_Setup.md) (np. `llama3-8b`).
+4. Kliknij **Execute Workflow** i wpisuj polecenia w okienku czatu n8n.
+
+## Przykład użycia
+```
+Ty: "Dodaj zadanie 'Naprawić bugi' do projektu 'Strona WWW'"
+Agent: "Gotowe, zadanie dodane!"
+```
+

--- a/docs/AI_Sub_Agent_Demo.md
+++ b/docs/AI_Sub_Agent_Demo.md
@@ -1,0 +1,28 @@
+# Demo podagentów (jak zespół piszący bloga)
+
+## O co chodzi?
+Wyobraź sobie redakcję. Redaktor naczelny prosi kilku reporterów o pomoc:
+jednego o research, innego o napisanie tytułów, kolejnego o napisanie
+paragrafów, a jeszcze innego o znalezienie obrazka. Ten workflow pokazuje, jak
+taka współpraca wygląda w n8n.
+
+## Kto tu pracuje
+- **Blog Writer Agent** – redaktor naczelny, który scala wszystko w jedną całość.
+- **Research Agent** – reporter zbierający informacje z internetu.
+- **Titles and Structure Tool** – pomaga ułożyć tytuł i plan artykułu.
+- **Write Section Tool** – pisze każdy akapit.
+- **Generate Image Tool** – dobiera grafikę pasującą do tekstu.
+
+## Jak przetestować
+1. Zaimportuj w n8n plik `AI Sub Agent Demo.json`.
+2. Ustaw lokalny model zgodnie z poradnikiem
+   [Local_LLM_Setup.md](Local_LLM_Setup.md) – w każdym węźle wybierz `Local
+   OpenAI` i odpowiedni model.
+3. Kliknij **Execute Workflow** i w czacie poproś: „Napisz artykuł o zdrowym
+   śnie”. Zobaczysz, jak kolejne narzędzia kolejno się uruchamiają.
+
+## Co możesz zmienić
+- Zamień modele na inne (np. `mixtral-8x7b` zamiast `llama3-8b`).
+- Podłącz własne źródła danych do Research Agenta.
+- Dodaj dodatkowy krok, np. korektę języka przez **Bielika**.
+

--- a/docs/Deep_Research_Agent.md
+++ b/docs/Deep_Research_Agent.md
@@ -1,0 +1,27 @@
+# Agent głębokiego researchu (internetowy detektyw)
+
+## Co to jest?
+Gdy potrzebujesz odpowiedzi na trudne pytania, ten agent działa jak
+dociekliwy detektyw. Potrafi przeszukiwać internet i zbierać informacje z
+różnych źródeł, po czym streszcza je w prosty sposób.
+
+## Jak wygląda śledztwo
+1. **Wiadomość z Telegrama** – pytasz np. „Jak działa energia słoneczna?”.
+2. **Filter** – upewnia się, że masz dostęp do agenta.
+3. **AI Agent** – decyduje, czy wystarczy szybkie wyszukiwanie (Sonar) czy
+   potrzebne jest głębsze kopanie (Sonar Pro).
+4. **Streszczenie** – agent zbiera znalezione informacje i odsyła zwięzłą
+   odpowiedź.
+
+## Jak uruchomić
+1. Zaimportuj `Deep_Research_Agent.json` do n8n.
+2. W węźle z modelem ustaw lokalny LLM (np. `qwen2-7b`) według
+   [Local_LLM_Setup.md](Local_LLM_Setup.md).
+3. Jeśli nie chcesz korzystać z usług Perplexity, podłącz własne źródło danych
+   lub prosty RAG.
+4. Kliknij **Execute Workflow** i zadawaj pytania w okienku czatu.
+
+## Podpowiedź
+Możesz rozszerzyć agenta, aby zapisywał najciekawsze znaleziska w notatniku lub
+wysyłał je e‑mailem do ciebie.
+

--- a/docs/Deep_Research_V2_RAG.md
+++ b/docs/Deep_Research_V2_RAG.md
@@ -1,0 +1,27 @@
+# Agent researchu V2 z własnym notesem (RAG)
+
+## Co go wyróżnia?
+To jak detektyw, który oprócz internetu ma własny uporządkowany notes. Notesem
+jest baza Supabase, gdzie można wrzucać dokumenty (np. PDF) i później szybko je
+odnajdywać.
+
+## Jak przebiega praca
+1. **Telegram Trigger** – odbiera pytania lub dokumenty.
+2. **Split & Embed** – jeśli wyślesz plik, agent dzieli go na małe kawałki i
+   zapisuje w bazie Supabase.
+3. **AI Agent** – gdy zadasz pytanie, agent sięga do internetu i do swojego
+   „notesu”, aby skleić pełną odpowiedź.
+
+## Uruchomienie krok po kroku
+1. W n8n zaimportuj plik `Deep_Research_V2___RAG.json`.
+2. Zgodnie z [Local_LLM_Setup.md](Local_LLM_Setup.md) ustaw lokalny model (np.
+   `qwen2-7b`) we wszystkich węzłach LLM.
+3. Ustaw połączenie z bazą Supabase (adres, klucz API). W tutorialach Supabase
+   znajdziesz darmową wersję do testów.
+4. Kliknij **Execute Workflow** i spróbuj wysłać plik PDF oraz pytanie na jego
+   temat.
+
+## Dalsze pomysły
+- Możesz dodać przeszukiwanie własnego folderu z notatkami.
+- Zastąp Supabase inną bazą wektorową, jeśli wolisz (np. Chroma).
+

--- a/docs/Local_LLM_Setup.md
+++ b/docs/Local_LLM_Setup.md
@@ -1,0 +1,53 @@
+# Przewodnik konfiguracji lokalnych modeli LLM
+
+## 1. Co będziemy robić
+Ten poradnik pokazuje, jak uruchomić agentów z tego repozytorium na własnym komputerze
+bez internetu. Wszystko opisane jest prostym językiem, aby nawet początkujący mogli
+spróbować swoich sił.
+
+## 2. Czego potrzebujemy
+1. **Komputer z mocną kartą graficzną** – Twój sprzęt z RTX 5080 i 32 GB RAM świetnie się nadaje.
+2. **Program do uruchamiania modeli** – użyjemy [LM Studio](https://lmstudio.ai) (łatwy interfejs) lub [Ollama](https://ollama.com) (działa z terminala).
+3. **n8n** – tutaj działają wszystkie agentowe "przepisy". Możesz skorzystać z wersji Desktop [z tej strony](https://n8n.io).
+
+## 3. Pobieranie modeli
+### 3.1 Otwórz LM Studio
+1. Uruchom LM Studio i przejdź do zakładki **Models**.
+2. Wpisz nazwę modelu w wyszukiwarkę i kliknij **Download**.
+
+### 3.2 Jakie modele pobrać
+| Zastosowanie | Nazwa modelu w LM Studio | Do czego służy |
+|-------------|-------------------------|---------------|
+| Główny mózg asystenta | `mixtral-8x7b-instruct` | rozumienie pytań i sterowanie innymi agentami |
+| Szybkie zadania (np. pogoda) | `phi-3-mini` | krótkie odpowiedzi, działa błyskawicznie |
+| Głęboki research | `qwen2-7b-instruct` | analizuje i łączy informacje |
+| Piękny język polski | `bielik-11b` | tłumaczenia i poprawa stylu |
+| Transkrypcja audio | `faster-whisper-large-v3` | zamienia mowę na tekst |
+
+> Jeśli model jest zbyt duży, w LM Studio wybierz opcję **Quantized** (np. 4-bit), wtedy zmieści się w pamięci karty graficznej.
+
+## 4. Uruchomienie lokalnego serwera modeli
+1. W LM Studio przejdź do zakładki **Server**.
+2. Kliknij **Start** – pojawi się adres, np. `http://localhost:8080`.
+3. Zanotuj ten adres; w n8n ustawimy go jako "OpenAI Base URL".
+
+## 5. Podłączenie modeli w n8n
+1. Uruchom n8n i zaimportuj workflow, np. `Personal Assistant.json`.
+2. Wejdź w zakładkę **Credentials** → **OpenAI** → dodaj nowe i nazwij je `Local OpenAI`.
+3. W polu **Base URL** wpisz `http://localhost:8080/v1`, a pole z kluczem API zostaw puste.
+4. Otwórz węzeł z modelem (np. `GPT-4.1`) i wybierz w nim poświadczenia `Local OpenAI`. Zmień nazwę modelu na taką, jak w LM Studio (np. `mixtral-8x7b-instruct`).
+5. Powtórz dla pozostałych węzłów: research (`qwen2-7b-instruct`), szybkie zadania (`phi-3-mini`), tłumaczenia (`bielik-11b`).
+6. Dla transkrypcji głosu dodaj węzeł **HTTP Request** kierujący na `faster-whisper`.
+
+## 6. Korzystanie z agentów
+1. W n8n kliknij **Execute Workflow**.
+2. Otwórz Telegram i wyślij wiadomość do bota powiązanego z `Personal Assistant`.
+3. Zadawaj pytania po polsku. Asystent sam dobierze model i odpowie.
+4. Spróbuj też innych agentów z folderu `docs/` – każdy działa podobnie, tylko ma inne zadania (np. zarządzanie projektami, tworzenie blogów).
+
+## 7. Co dalej
+- Testuj różne modele. Jeśli odpowiedzi są wolne, wybierz mniejszy model.
+- Zajrzyj do plików `docs/*.md` aby dowiedzieć się, co robi każdy agent.
+- Ucz się poprzez zabawę – modyfikuj workflowy i zobacz, co się stanie!
+
+Powodzenia i miłej nauki!

--- a/docs/Personal_Assistant.md
+++ b/docs/Personal_Assistant.md
@@ -1,0 +1,52 @@
+# Asystent osobisty (jak przyjaciel, który pamięta wszystko)
+
+## Co robi?
+Wyobraź sobie, że masz drużynę małych pomocników. Jeden zna się na pogodzie,
+drugi pilnuje wydatków, a trzeci potrafi pisać maile. Nad nimi czuwa
+**Dyrygent** – Orchestrator. Kiedy wysyłasz wiadomość, Dyrygent decyduje, którego
+pomocnika poprosić o działanie i łączy odpowiedzi w jedną wiadomość.
+
+## Jak działa w środku
+1. **Wiadomość z Telegrama** – piszesz tekst albo nagrywasz głos.
+2. **Transkrypcja** – jeśli to nagranie, „maszyna do pisania” (Whisper) zamienia
+   głos na tekst.
+3. **Dyrygent** – Orchestrator czyta tekst i wybiera odpowiedniego pomocnika:
+   - *Badacz* szuka informacji w sieci,
+   - *Księgowy* zapisuje wydatki,
+   - *Sekretarz* tworzy lub streszcza e‑maile,
+   - *Pisarz* tworzy dłuższe teksty.
+4. **Powrót odpowiedzi** – wynik wraca do ciebie na Telegramie.
+
+## Jak uruchomić agenta krok po kroku
+1. **Przygotuj modele** – postępuj według poradnika
+   [Local_LLM_Setup.md](Local_LLM_Setup.md). Pobierz np. `mixtral-8x7b` i
+   `phi-3-mini`, uruchom serwer w LM Studio.
+2. **Włącz n8n** – pobierz wersję Desktop, włącz i kliknij **Import**, aby
+   wczytać plik `Personal Assistant.json`.
+3. **Połącz z modelami**
+   - Wejdź w **Credentials → OpenAI → Add** i nazwij połączenie `Local OpenAI`.
+   - W polu **Base URL** wpisz adres serwera z LM Studio, np.
+     `http://localhost:8080/v1`. Pole z kluczem pozostaw puste.
+   - Otwórz każdy węzeł LLM (np. `GPT‑4.1`) i wybierz połączenie `Local OpenAI`,
+     a w polu model wpisz nazwę pobranego modelu.
+4. **Skonfiguruj Telegram** – w aplikacji Telegram napisz do `@BotFather`,
+   utwórz nowego bota i skopiuj token. W n8n w węźle `Telegram Trigger` wklej
+   ten token.
+5. **Start** – kliknij **Execute Workflow** i napisz do swojego bota na
+   Telegramie. Powinieneś otrzymać odpowiedź od Asystenta.
+
+## Przykładowa rozmowa
+```
+Ty: "Dodaj wydatek 15 zł na kawę"
+Asystent: "Zapisano: kawa – 15 zł"
+
+Ty: "A jaka jutro będzie pogoda w Warszawie?"
+Asystent: "Jutro 12 °C i deszcz, nie zapomnij parasola!"
+```
+
+## Jak rozwijać dalej
+- Dodaj tłumacza **Bielik**, aby odpowiedzi brzmiały jeszcze naturalniej po
+  polsku.
+- Napisz własnego pomocnika, np. do planowania diety – Dyrygent zajmie się jego
+  włączeniem w rozmowę.
+

--- a/docs/Second_Brain_Agent.md
+++ b/docs/Second_Brain_Agent.md
@@ -1,0 +1,28 @@
+# Agent Drugiego Mózgu (twój osobisty bibliotekarz)
+
+## Idea
+Zamiast trzymać ważne informacje w głowie, możesz je odkładać do „drugiego
+mózgu”. Agent zapisuje notatki w bazie Supabase i potrafi je później znaleźć,
+gdy o coś zapytasz.
+
+## Jak to działa
+1. **Dodawanie informacji** – wysyłasz wiadomość lub plik. Agent tworzy z niego
+   wektor i zapisuje w bazie (jak spis treści w bibliotece).
+2. **Pytanie** – prosisz: „Przypomnij mi ciekawostki o Marsie”.
+3. **Wyszukiwanie** – agent przeszukuje bazę i zwraca pasujące fragmenty.
+4. **Odpowiedź** – z odnalezionych notatek tworzy krótkie podsumowanie.
+
+## Uruchomienie krok po kroku
+1. Zaimportuj w n8n `Second_Brain_Agent.json`.
+2. Skonfiguruj połączenie z Supabase (adres i klucz). Możesz użyć darmowego
+   konta.
+3. Ustaw lokalny model LLM oraz embeddings zgodnie z
+   [Local_LLM_Setup.md](Local_LLM_Setup.md) – np. `llama3-8b` i
+   `text-embedding-nomic`.
+4. Kliknij **Execute Workflow**. Dodaj kilka notatek i spróbuj o nie zapytać.
+
+## Pomysły na rozwój
+- Połącz agenta z YouTube lub podcastami, aby automatycznie zapisywać
+  transkrypcje.
+- Dodaj funkcję przypomnień wysyłanych na e‑mail.
+


### PR DESCRIPTION
## Summary
- document key agent workflows and how to adapt them for local models
- configure Personal Assistant workflow to use local LLMs and local Whisper
- translate all agent guides and setup instructions into Polish
- rewrite agent docs with beginner-friendly, step-by-step explanations

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_b_68a75f85d294832dbe7bbf1aa0dec99c